### PR TITLE
chore: bump `cenkalti/backoff` from `v4` to `v5`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.2
 
 require (
 	github.com/DecisiveAI/mdai-operator v0.1.1
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/stretchr/testify v1.10.0
 	github.com/valkey-io/valkey-go v1.0.53
 	github.com/valkey-io/valkey-go/mock v1.0.53

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/DecisiveAI/mdai-operator v0.1.1 h1:LWGp+ydTR1+lLtQfxzvxY0CliliBsVhR21DogNv5Emk=
 github.com/DecisiveAI/mdai-operator v0.1.1/go.mod h1:5qMuSoogAyOvCRM/x5KwON5vRpXr4gqVvhJahSiXuLo=
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
```
{"level":"warn","timestamp":"2025-02-10T17:41:28.118-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":1,"duration":0.580602544}
{"level":"warn","timestamp":"2025-02-10T17:41:33.702-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":2,"duration":0.751296844}
{"level":"warn","timestamp":"2025-02-10T17:41:39.456-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":3,"duration":1.630335382}
{"level":"warn","timestamp":"2025-02-10T17:41:46.088-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":4,"duration":1.190582823}
{"level":"warn","timestamp":"2025-02-10T17:41:52.281-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":5,"duration":3.277958811}
{"level":"warn","timestamp":"2025-02-10T17:42:00.561-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":6,"duration":2.825365102}
{"level":"warn","timestamp":"2025-02-10T17:42:08.390-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":7,"duration":6.186877679}
{"level":"warn","timestamp":"2025-02-10T17:42:19.579-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":8,"duration":6.909370748}
{"level":"warn","timestamp":"2025-02-10T17:42:31.491-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":9,"duration":18.214822036}
{"level":"warn","timestamp":"2025-02-10T17:42:54.710-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":10,"duration":12.71864368}
{"level":"warn","timestamp":"2025-02-10T17:43:12.432-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":11,"duration":23.10994276}
{"level":"warn","timestamp":"2025-02-10T17:43:40.545-0700","caller":"event-handler-webservice/main.go:86","msg":"failed to initialize valkey client. retrying...","retry_count":12,"duration":26.243990753}
{"level":"fatal","timestamp":"2025-02-10T17:44:11.792-0700","caller":"event-handler-webservice/main.go:93","msg":"failed to get valkey client","error":"dial tcp: lookup mdai-valkey-primary.mdai.svc.cluster.local: i/o timeout"}
```