### PR TITLE
Skip go-coverage-report on merge to main

### DIFF
--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -90,6 +90,7 @@ jobs:
           path: coverage.out
 
       - name: Generate Code Coverage Report
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
         uses: fgrosse/go-coverage-report@v1.1.1
         id: report
         with:


### PR DESCRIPTION
go-coverage-report tries to pull an artifact from `main` even when it's running on `main`, that results in an error and the job aborts.

This change should prevent that action from running when the PR is merged to `main`