### PR TITLE
feat: add connection name and timestamp to configmap

### DIFF
--- a/internal/connection/connections.go
+++ b/internal/connection/connections.go
@@ -3,6 +3,7 @@ package connection
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +37,7 @@ func updateConfigMapWithConnection(ctx context.Context, k8sClient kubernetes.Int
 	}
 	cm.Data[connectionName] = connectionData
 	cm.Data[connectionsConfigmapConnectionNameKey] = connectionName
-	cm.Data[fmt.Sprintf(connectionsConfigmapLastEditedKey, connectionName)] = fmt.Sprintf("%v", time.Now().UTC().Unix())
+	cm.Data[fmt.Sprintf(connectionsConfigmapLastEditedKey, connectionName)] = strconv.FormatInt(time.Now().UTC().Unix(), 10)
 
 	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("error while updating configmap: %w", err)

--- a/internal/connection/connections.go
+++ b/internal/connection/connections.go
@@ -3,6 +3,7 @@ package connection
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,6 +11,8 @@ import (
 )
 
 const connectionsConfigmapName = "mdai-octant-connections"
+const connectionsConfigmapConnectionNameKey = "connectionName"
+const connectionsConfigmapLastEditedKey = "%s-last-edited"
 
 type Status struct {
 	ReceivingData bool   `json:"receivingData"`
@@ -30,6 +33,8 @@ func updateConfigMapWithConnection(ctx context.Context, k8sClient kubernetes.Int
 		cm.Data = make(map[string]string)
 	}
 	cm.Data[connectionName] = connectionData
+	cm.Data[connectionsConfigmapConnectionNameKey] = connectionName
+	cm.Data[fmt.Sprintf(connectionsConfigmapLastEditedKey, connectionName)] = fmt.Sprintf("%v", time.Now().UTC().Unix())
 
 	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("error while updating configmap: %w", err)

--- a/internal/connection/connections.go
+++ b/internal/connection/connections.go
@@ -10,9 +10,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const connectionsConfigmapName = "mdai-octant-connections"
-const connectionsConfigmapConnectionNameKey = "connectionName"
-const connectionsConfigmapLastEditedKey = "%s-last-edited"
+const (
+	connectionsConfigmapName              = "mdai-octant-connections"
+	connectionsConfigmapConnectionNameKey = "connectionName"
+	connectionsConfigmapLastEditedKey     = "%s-last-edited"
+)
 
 type Status struct {
 	ReceivingData bool   `json:"receivingData"`


### PR DESCRIPTION
<!--
For Work In Progress pull requests, please use the Draft PR feature.

For a timely review/response, please avoid force-pushing additional
commits if your PR already received reviews or comments.

Before submitting a pull request, please ensure you've done the following:
- Create small PRs. In most cases this will be possible.
- Provide tests for your changes.
- Add/update relevant documentation(s).
- Fill out the pull request template.
- Ensure your PR title follow the guideline described in: 
  https://github.com/MyDecisive/changelogs?tab=readme-ov-file#pull-request-title
-->

## Description
<!--
Please describe the changes you made in this pull request.

If applicable, please feel free to include screenshots to make it
easier for reviewers understand your pull request. 

If there are any relevant documentations that help explain your pull
request, please feel free to include them as well.
-->

- ENG-1229

Goal of this PR is to add the latest connection name and last edited timestamp to the configmap to allow clarity applet to use it for its computation.

## What type of PR is this? (only check one)
<!--
If you need to check more than one (except if the other type is `doc`, 
always do add more doc) to properly capture the PR type, please 
consider splitting up your PR.

If you selected Other, please ensure the type you provided
is one of the valid types outlined in
https://github.com/MyDecisive/changelogs?tab=readme-ov-file#type
-->

- [x] Feature (`feat`)
- [ ] Bug Fix (`fix`)
- [ ] Refactor (`refactor`)
- [ ] Documentation Update (`doc`)
- [ ] Other, please specify: 

### Does this PR introduce any breaking changes?
- [x] No
- [ ] Yes, and this is why: 
- [ ] I need help determining if there are any breaking changes

### Does the PR title type prefix match the selected type?
- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help select the right one

## Added/updated tests?
_Please keep the code coverage percentage at 80% and above._
- [ ] Yes
- [x] No, and this is why: 
- [ ] I need help with writing tests

<!--
Uncomment this section if needed:
## Updated [`mdai-labs`](https://github.com/MyDecisive/mdai-labs) to reflect changes done in this PR?
- [ ] Yes
- [ ] N/A
- [ ] I need help, please elaborate: 
-->
